### PR TITLE
Add React 19 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build-storybook": "storybook build"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.24.7",


### PR DESCRIPTION
Add React 19 in peer dependencies

Fix https://github.com/AnyRoad/react-json-view-lite/issues/34

According to https://github.com/AnyRoad/react-json-view-lite/issues/34#issuecomment-2571256404 all the people that tried React 19 with this lib reported no problem.

I took a look at the code and couldn't find any code that would be problematic for React 19 (defaultProps, forwardRef...) so it should be relatively safe to allow React 19 (and you can still revert if needed)


Docusaurus v3.7 is running on React 19 and our debug plugin uses this lib already in production for months, and for some of our users.

https://docusaurus.io/__docusaurus/debug

