### PR TITLE
Fix: beforeExpandChange not delegated

### DIFF
--- a/src/DataRenderer.tsx
+++ b/src/DataRenderer.tsx
@@ -200,6 +200,7 @@ function ExpandableObject({
               level={childLevel}
               shouldExpandNode={shouldExpandNode}
               clickToExpandNode={clickToExpandNode}
+              beforeExpandChange={beforeExpandChange}
               outerRef={outerRef}
             />
           ))}


### PR DESCRIPTION
Error description:
beforeExpandChange does not work in nested objects

Observation:
Property is Missing in nested DataRenderer (see attached [video](https://github.com/user-attachments/assets/b734e92e-1e39-458b-993f-63bebb4fecab ) )

Fix: 
Add missing property to ExpandableObject

Thanks for your work. I wrapped your viewer with a state to keep Objects open on rerender. 



